### PR TITLE
Link to full URL in RSS Feed

### DIFF
--- a/source/feed.xml.builder
+++ b/source/feed.xml.builder
@@ -9,10 +9,11 @@ xml.feed "xmlns" => "http://www.w3.org/2005/Atom" do
   xml.author { xml.name "Andy Stabler" }
 
   blog.articles[0..10].each do |article|
+    article_url = config.domain + article.url
     xml.entry do
       xml.title article.title
-      xml.link "rel" => "alternate", "href" => article.url
-      xml.id config.domain + article.url
+      xml.link "rel" => "alternate", "href" => article_url
+      xml.id article_url
       xml.published article.date.to_time.iso8601
       xml.updated article.date.to_time.iso8601
       xml.author { xml.name "Andy Stabler" }


### PR DESCRIPTION
Noticed when trying to copy from my RSS reader your RSS feed just contains the relative path for a post, rather than the full URL.

Copied the approach you've used for the `id` field to glom together the domain and relative path, and then extracted it once per loop.

🎉 